### PR TITLE
[Docker] Resolves #11 : avoid hardcoded credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,15 @@ RUN python manage.py migrate
 # collect static images
 RUN python manage.py collectstatic
 
+# get build arguments (credentials)
+ARG dj_email
+ARG dj_username
+ARG dj_password
+
 # create superuser
-ENV DJANGO_SUPERUSER_EMAIL="admin@locahost.local"
-ENV DJANGO_SUPERUSER_USERNAME="admin"
-ENV DJANGO_SUPERUSER_PASSWORD="GooglePhish"
+ENV DJANGO_SUPERUSER_EMAIL=${dj_email}
+ENV DJANGO_SUPERUSER_USERNAME=${dj_username}
+ENV DJANGO_SUPERUSER_PASSWORD=${dj_password}
 RUN python manage.py createsuperuser --noinput
 
 # expose ports

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,9 @@ RUN python manage.py migrate
 RUN python manage.py collectstatic
 
 # get build arguments (credentials)
-ARG dj_email
-ARG dj_username
-ARG dj_password
+ARG dj_email=admin@mail.local
+ARG dj_username=admin
+ARG dj_password=GooglePhish
 
 # create superuser
 ENV DJANGO_SUPERUSER_EMAIL=${dj_email}

--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@
 
     > ℹ️ Please replace build arguments by your credentials
     ```bash
-      sudo docker build -t googlephish --build-arg dj_email="admin@mail.bzh" --build-arg dj_username="username" --build-arg dj_password="password" . 
+      sudo docker build -t googlephish --build-arg dj_email="admin@mail.bzh" --build-arg dj_username="username" --build-arg dj_password="GooglePhish" . 
     ```
 
+
 - Using Docker Compose
+> ⚠️ Doesn't work yet 
 
     ```bash
     docker-compose up

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@
 
     > ℹ️ Please replace build arguments by your credentials
     ```bash
-      sudo docker build -t googlephish --build-arg dj_email="admin@mail.bzh" --build-arg dj_username="username" --build-arg dj_password="GooglePhish" . 
+      sudo docker build -t googlephish --build-arg dj_email="admin@mail.local" --build-arg dj_username="admin" --build-arg dj_password="GooglePhish" . 
+    ```
+    and run it :
+    ```bash
+    docker run -d -p 8000:8000 googlephish
     ```
 
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
       ```
 
   - run docker image
-
+    > ℹ️ Please replace build arguments by your credentials
       ```bash
-      docker run -d -p 8000:8000 dmdhrumilmistry/googlephish
+      sudo docker build -t googlephish --build-arg dj_email="admin@mail.bzh" --build-arg dj_username="username" --build-arg dj_password="password" . 
       ```
 
 - Build Image and run using build command

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@
       ```
 
   - run docker image
-    > ℹ️ Please replace build arguments by your credentials
+
       ```bash
-      sudo docker build -t googlephish --build-arg dj_email="admin@mail.bzh" --build-arg dj_username="username" --build-arg dj_password="password" . 
+      docker run -d -p 8000:8000 dmdhrumilmistry/googlephish
       ```
 
 - Build Image and run using build command
 
+    > ℹ️ Please replace build arguments by your credentials
     ```bash
-    docker build -t googlephish .
-    docker run -d -p 8000:8000 googlephish
+      sudo docker build -t googlephish --build-arg dj_email="admin@mail.bzh" --build-arg dj_username="username" --build-arg dj_password="password" . 
     ```
 
 - Using Docker Compose

--- a/README.md
+++ b/README.md
@@ -109,12 +109,6 @@
     ```
     http://127.0.0.1:8000/pawned
     ```
-    
-- If you using the docker image you can change defaults credentials in `Dockerfile` before build it or logging you with this account
-
-    username : `admin`
-    password : `GooglePhish`
-
 
 ## Start Server
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,23 @@
 
 - Build Image and run using build command
 
-    > ℹ️ Please replace build arguments by your credentials
+    
     ```bash
-      sudo docker build -t googlephish --build-arg dj_email="admin@mail.local" --build-arg dj_username="admin" --build-arg dj_password="GooglePhish" . 
+      sudo docker build -t googlephish . 
     ```
+    You can specify your credentials using build arguments like this :
+    > ℹ️ Please replace build arguments by your credentials
+    ``` bash
+    sudo docker build -t googlephish --build-arg dj_email="admin@mail.local" --build-arg dj_username="admin" --build-arg dj_password="GooglePhish" . 
+    ```
+
     and run it :
     ```bash
     docker run -d -p 8000:8000 googlephish
     ```
-
+    If you have build the dockerfile with no arguments, the default credentials are :
+    * Username : `admin`
+    * Password : `GooglePhish`
 
 - Using Docker Compose
 > ⚠️ Doesn't work yet 


### PR DESCRIPTION
Fixes #11 

# Related Issues :
 - #11 
# Proposed Changes:

Add arguments to docker file for allow to a user to specify his super user credentials before build and avoid to have these information hardcoded

# Features : 

- ✨ Added build arguments in `dockerfile`
- ⚡️ Improve documentation 